### PR TITLE
Use strings step definition rather than regular expressions

### DIFF
--- a/src/BehatFixturesLoader/Context/FixturesContext.php
+++ b/src/BehatFixturesLoader/Context/FixturesContext.php
@@ -24,7 +24,7 @@ class FixturesContext implements KernelAwareContext, EntityFactoryAware
     }
 
     /**
-     * @Given /^there are following :name:$/
+     * @Given there are following :name:
      * @param $name
      */
     public function followingEntities($name, TableNode $data)


### PR DESCRIPTION
Now step definition to load following entities is not matched correctly.
For example:

```
Background:
  Given there are following "entityName":
```

So change definition to use strings rather than regular expressions [String steps](https://github.com/cucumber/cucumber/wiki/Step-Definitions#string-steps).

I also consider regexp:

```
@Given /^(?:|there )are following (?P<name>[^"]+):$/
```

but it's less readable.
