### PR TITLE
omitting entity constructor during creation of new instances

### DIFF
--- a/src/BehatFixturesLoader/EntityFactory/EntityFactory.php
+++ b/src/BehatFixturesLoader/EntityFactory/EntityFactory.php
@@ -47,7 +47,9 @@ class EntityFactory
 
         $entityFullName = $entityMetadata->getFullName();
 
-        $entity = new $entityFullName();
+        $reflection = new \ReflectionClass($entityFullName);
+
+        $entity = $reflection->newInstanceWithoutConstructor();
 
         $classMetadata = $this->entityManager->getClassMetadata($entityFullName);
 


### PR DESCRIPTION
In case of an entity with constructor arguments the `EntityFactory` returns an error of missing constructor arguments.

``` php
class Foo {
    private $bar;
    public function __construct($bar) {
        $this->bar = $bar;
    }
    public function getBar() { ... }
    public function setBar($bar) { ... }
}
```

By using a reflection you can skip passing arguments to the constructor. The same technique is used by `Doctrine`.
